### PR TITLE
Persist settings locally

### DIFF
--- a/src/main/modules/store.ts
+++ b/src/main/modules/store.ts
@@ -4,6 +4,11 @@ export interface Settings {
   startWithWindows: boolean
   theme: string
   toggleKeybind: string[]
+  inputDevice?: string
+  autoSave?: boolean
+  shortcuts?: Record<string, string>
+  confidence?: number
+  punctuation?: boolean
 }
 
 let store: any = null
@@ -14,7 +19,12 @@ export async function initializeStore() {
     defaults: {
       startWithWindows: false,
       theme: 'light',
-      toggleKeybind: []
+      toggleKeybind: [],
+      inputDevice: undefined,
+      autoSave: false,
+      shortcuts: {},
+      confidence: 80,
+      punctuation: true
     }
   })
 }
@@ -23,7 +33,12 @@ export function getSettings(): Settings {
   return {
     startWithWindows: store.get('startWithWindows'),
     theme: store.get('theme'),
-    toggleKeybind: store.get('toggleKeybind')
+    toggleKeybind: store.get('toggleKeybind'),
+    inputDevice: store.get('inputDevice'),
+    autoSave: store.get('autoSave'),
+    shortcuts: store.get('shortcuts'),
+    confidence: store.get('confidence'),
+    punctuation: store.get('punctuation')
   }
 }
 
@@ -35,7 +50,7 @@ export function saveSettings(settings: Partial<Settings>) {
       store.set(key, value)
     }
   })
-  
+
   // Handle specific settings
   if ('startWithWindows' in settings) {
     app.setLoginItemSettings({
@@ -47,13 +62,22 @@ export function saveSettings(settings: Partial<Settings>) {
 // Add proper store change event handling
 export function onSettingsChange(callback: (key: string, value: any) => void) {
   if (!store) return
-  
+
   // Listen for changes on each setting key
-  const keys: (keyof Settings)[] = ['startWithWindows', 'theme', 'toggleKeybind']
-  keys.forEach(key => {
+  const keys: (keyof Settings)[] = [
+    'startWithWindows',
+    'theme',
+    'toggleKeybind',
+    'inputDevice',
+    'autoSave',
+    'shortcuts',
+    'confidence',
+    'punctuation'
+  ]
+  keys.forEach((key) => {
     // Use the correct method signature for onDidChange
     store.onDidChange(key.toString(), (newValue: any) => {
       callback(key.toString(), newValue)
     })
   })
-}   
+}

--- a/src/renderer/src/hooks/useSettings.tsx
+++ b/src/renderer/src/hooks/useSettings.tsx
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+export interface SettingsState {
+  inputDevice?: string
+  autoSave?: boolean
+  shortcuts?: Record<string, string>
+  confidence?: number
+  punctuation?: boolean
+}
+
+interface SettingsContextValue {
+  settings: SettingsState
+  setSetting: (key: keyof SettingsState, value: any) => void
+  saveSettings: () => void
+}
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(undefined)
+
+export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [settings, setSettings] = useState<SettingsState>(() => {
+    try {
+      return JSON.parse(localStorage.getItem('settings') || '{}')
+    } catch {
+      return {}
+    }
+  })
+
+  useEffect(() => {
+    const handler = (_: unknown, { key, value }: { key: string; value: any }) => {
+      setSettings(prev => ({ ...prev, [key]: value }))
+    }
+    if (window.electron?.ipcRenderer) {
+      window.electron.ipcRenderer.invoke('get-settings').then(stored => {
+        setSettings(prev => ({ ...prev, ...stored }))
+      })
+      window.electron.ipcRenderer.on('settings-changed', handler)
+    }
+    return () => {
+      window.electron?.ipcRenderer.removeListener('settings-changed', handler)
+    }
+  }, [])
+
+  const setSetting = (key: keyof SettingsState, value: any) => {
+    setSettings(prev => ({ ...prev, [key]: value }))
+  }
+
+  const saveSettings = () => {
+    localStorage.setItem('settings', JSON.stringify(settings))
+    window.electron?.ipcRenderer.send('save-settings', settings)
+  }
+
+  return (
+    <SettingsContext.Provider value={{ settings, setSetting, saveSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+
+export function useSettings() {
+  const ctx = useContext(SettingsContext)
+  if (!ctx) {
+    throw new Error('useSettings must be used within SettingsProvider')
+  }
+  return ctx
+}

--- a/src/renderer/src/main-window/Settings.tsx
+++ b/src/renderer/src/main-window/Settings.tsx
@@ -14,9 +14,11 @@ import TranscriptionSettings from "@renderer/main-window/Settings/Transcription"
 import OutputSettings from "@renderer/main-window/Settings/Output";
 import ShortcutsSettings from "@renderer/main-window/Settings/Shortcuts";
 import PrivacySettings from "@renderer/main-window/Settings/Privacy";
+import { useSettings } from "../hooks/useSettings";
 
 export default function TranscriptionSettingsFluent() {
   // --- state --------------------------------------------------------------
+  const { saveSettings } = useSettings();
   const [selectedTab, setSelectedTab] = React.useState<
     "audio" | "transcription" | "output" | "shortcuts" | "privacy"
   >("audio");
@@ -165,7 +167,7 @@ export default function TranscriptionSettingsFluent() {
         {/* Right: Buttons */}
         <div style={{ display: "flex", gap: 12 }}>
           <Button appearance="secondary">Reset to Defaults</Button>
-          <Button appearance="primary">Save Settings</Button>
+          <Button appearance="primary" onClick={saveSettings}>Save Settings</Button>
         </div>
       </div>
     </div>

--- a/src/renderer/src/main-window/Settings/Audio.tsx
+++ b/src/renderer/src/main-window/Settings/Audio.tsx
@@ -9,10 +9,12 @@ import {
 import { Mic24Regular } from "@fluentui/react-icons";
 import SectionCard from "./Sectioncard";
 import Row from "./Row";
+import { useSettings } from "../../hooks/useSettings";
 
 const AudioSettings: React.FC = () => {
+  const { settings, setSetting } = useSettings();
   const [devices, setDevices] = React.useState<MediaDeviceInfo[]>([]);
-  const [selectedDevice, setSelectedDevice] = React.useState<string | undefined>();
+  const [selectedDevice, setSelectedDevice] = React.useState<string | undefined>(settings.inputDevice);
 
   React.useEffect(() => {
     async function loadDevices() {
@@ -37,7 +39,9 @@ const AudioSettings: React.FC = () => {
   }, []);
 
   const handleSelect = (_: any, data: any) => {
-    setSelectedDevice(data.optionValue as string);
+    const value = data.optionValue as string;
+    setSelectedDevice(value);
+    setSetting('inputDevice', value);
   };
 
   return (

--- a/src/renderer/src/main-window/Settings/Output.tsx
+++ b/src/renderer/src/main-window/Settings/Output.tsx
@@ -5,11 +5,12 @@ import { Label, Dropdown, Option, Input, Switch, Button, Text, Divider } from "@
 import { Folder24Regular } from "@fluentui/react-icons";
 import SectionCard from "./Sectioncard";
 import Row from "./Row";
+import { useSettings } from "../../hooks/useSettings";
 
 
 const OutputSettings: React.FC = () => {
-    // Add the use of React state for confidence and punctuation
-    const [autoSave, setAutoSave] = React.useState<boolean>(false);
+    const { settings, setSetting } = useSettings();
+    const [autoSave, setAutoSave] = React.useState<boolean>(settings.autoSave ?? false);
 
     return (<SectionCard
         icon={<Folder24Regular />}
@@ -72,7 +73,10 @@ const OutputSettings: React.FC = () => {
                     </div>
                     <Switch
                         checked={autoSave}
-                        onChange={(_, data) => setAutoSave(data.checked)}
+                        onChange={(_, data) => {
+                            setAutoSave(data.checked);
+                            setSetting('autoSave', data.checked);
+                        }}
                         aria-label="Auto save"
                     />
                 </Row>

--- a/src/renderer/src/main-window/Settings/Shortcuts.tsx
+++ b/src/renderer/src/main-window/Settings/Shortcuts.tsx
@@ -3,11 +3,13 @@ import { Label, Switch, Badge, Text, Divider, Dialog, DialogSurface, DialogBody,
 import { Keyboard24Regular } from "@fluentui/react-icons";
 import SectionCard from "./Sectioncard";
 import Row from "./Row";
+import { useSettings } from "../../hooks/useSettings";
 
 const ShortcutsSettings: React.FC = () => {
+    const { settings, setSetting } = useSettings();
 
     const [editingShortcut, setEditingShortcut] = React.useState<string | null>(null);
-    const [shortcuts, setShortcuts] = React.useState<Record<string, string>>({
+    const [shortcuts, setShortcuts] = React.useState<Record<string, string>>(settings.shortcuts || {
         startStop: "Ctrl+Shift+R",
         pauseResume: "Ctrl+Shift+P",
         save: "Ctrl+Shift+S",
@@ -35,7 +37,9 @@ const ShortcutsSettings: React.FC = () => {
 
     const saveShortcut = () => {
         if (capturedKeys.length > 0) {
-            setShortcuts({ ...shortcuts, [editingShortcut as string]: capturedKeys.join(" + ") });
+            const updated = { ...shortcuts, [editingShortcut as string]: capturedKeys.join(" + ") };
+            setShortcuts(updated);
+            setSetting('shortcuts', updated);
             setEditingShortcut(null);
             setCapturedKeys([]);
         }

--- a/src/renderer/src/main-window/Settings/Transcription.tsx
+++ b/src/renderer/src/main-window/Settings/Transcription.tsx
@@ -4,11 +4,12 @@ import { Label, Dropdown, Option, Slider, Switch, Badge, Text, Divider } from "@
 import { TextGrammarWand24Regular } from "@fluentui/react-icons";
 import SectionCard from "./Sectioncard";
 import Row from "./Row";
+import { useSettings } from "../../hooks/useSettings";
 
 const TranscriptionSettings: React.FC = () => {
-  // Add the use of React state for confidence and punctuation
-  const [confidence, setConfidence] = React.useState<number>(80);
-  const [punctuation, setPunctuation] = React.useState<boolean>(true);
+  const { settings, setSetting } = useSettings();
+  const [confidence, setConfidence] = React.useState<number>(settings.confidence ?? 80);
+  const [punctuation, setPunctuation] = React.useState<boolean>(settings.punctuation ?? true);
 
   return (
     <SectionCard
@@ -64,7 +65,11 @@ const TranscriptionSettings: React.FC = () => {
           <Label>Confidence Threshold</Label>
           <Slider
             value={confidence}
-            onChange={(_, data) => setConfidence(data.value as number)}
+            onChange={(_, data) => {
+              const val = data.value as number;
+              setConfidence(val);
+              setSetting('confidence', val);
+            }}
             max={100}
             step={5}
           />
@@ -98,7 +103,10 @@ const TranscriptionSettings: React.FC = () => {
             </div>
             <Switch
               checked={punctuation}
-              onChange={(_, data) => setPunctuation(data.checked)}
+              onChange={(_, data) => {
+                setPunctuation(data.checked);
+                setSetting('punctuation', data.checked);
+              }}
               aria-label="Auto punctuation"
             />
           </Row>

--- a/src/renderer/src/main-window/main.tsx
+++ b/src/renderer/src/main-window/main.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client'
 import App from './App'
 import { FluentProvider, webDarkTheme } from '@fluentui/react-components'
 import TranscriptionSettingsFluent from '@renderer/main-window/Settings'
+import { SettingsProvider } from '../hooks/useSettings'
 
 const rootElement = document.getElementById('root')
 if (!rootElement) {
@@ -17,8 +18,9 @@ const root = createRoot(rootElement)
 root.render(
   <StrictMode>
     <FluentProvider theme={webDarkTheme} style={{ height: '100%', width: '100%' }}>
-      <TranscriptionSettingsFluent />
+      <SettingsProvider>
+        <TranscriptionSettingsFluent />
+      </SettingsProvider>
     </FluentProvider>
-
   </StrictMode>
 )

--- a/src/renderer/src/overlay-window/App.tsx
+++ b/src/renderer/src/overlay-window/App.tsx
@@ -1,14 +1,32 @@
-import * as React from 'react';
-import { Button, Text, Title3 } from '@fluentui/react-components';
+import * as React from 'react'
+import { Button, Text, Title3 } from '@fluentui/react-components'
+import { useSettings } from '../hooks/useSettings'
 
 function App(): React.JSX.Element {
-  const ipcHandle = (): void => window.electron.ipcRenderer.send('ping');
+  const { settings } = useSettings()
+  const ipcHandle = (): void => window.electron.ipcRenderer.send('ping')
 
   return (
-    <div style={{ minWidth: 360, padding: 32, display: 'flex', flexDirection: 'column', gap: 20, alignItems: 'center', background: 'transparent', boxShadow: 'none' }}>
+    <div
+      style={{
+        minWidth: 360,
+        padding: 32,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 20,
+        alignItems: 'center',
+        background: 'transparent',
+        boxShadow: 'none'
+      }}
+    >
       <Title3>OVERLAY</Title3>
-      <Text>Build an Electron app with <b>React</b> and <b>TypeScript</b> using Fluent UI.</Text>
-      <Text>Try pressing <code>F12</code> to open the DevTools.</Text>
+      <Text>
+        Build an Electron app with <b>React</b> and <b>TypeScript</b> using Fluent UI.
+      </Text>
+      <Text>
+        Try pressing <code>F12</code> to open the DevTools.
+      </Text>
+      <Text>Current input device: {settings.inputDevice || 'system default'}</Text>
       <div style={{ display: 'flex', gap: 12 }}>
         <Button as="a" href="https://react.fluentui.dev/" target="_blank" appearance="primary">
           Fluent UI Docs
@@ -18,7 +36,7 @@ function App(): React.JSX.Element {
         </Button>
       </div>
     </div>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/src/renderer/src/overlay-window/main.tsx
+++ b/src/renderer/src/overlay-window/main.tsx
@@ -1,23 +1,26 @@
-import '../assets/overlay.css';
+import '../assets/overlay.css'
 
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App';
-import { FluentProvider, webDarkTheme } from '@fluentui/react-components';
-import Pill from '../components/Pill';
-const rootElement = document.getElementById('root');
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import { FluentProvider, webDarkTheme } from '@fluentui/react-components'
+import Pill from '../components/Pill'
+import { SettingsProvider } from '../hooks/useSettings'
+const rootElement = document.getElementById('root')
 if (!rootElement) {
-  throw new Error('Failed to find the root element');
+  throw new Error('Failed to find the root element')
 }
 
-console.log('Mounting React application...');
-const root = createRoot(rootElement);
+console.log('Mounting React application...')
+const root = createRoot(rootElement)
 
 root.render(
   <StrictMode>
     <FluentProvider theme={webDarkTheme}>
-      {/* <App /> */}
-      <Pill />
+      <SettingsProvider>
+        {/* <App /> */}
+        <Pill />
+      </SettingsProvider>
     </FluentProvider>
   </StrictMode>
-);
+)


### PR DESCRIPTION
## Summary
- add `useSettings` hook with `SettingsProvider`
- wrap main window with provider
- update settings screens to write to context
- save settings to electron store and `localStorage`
- expose saved settings in overlay window

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bbc3a4088327b034e64dd38a49bb