### PR TITLE
Persist settings locally

### DIFF
--- a/src/main/modules/store.ts
+++ b/src/main/modules/store.ts
@@ -4,6 +4,11 @@ export interface Settings {
   startWithWindows: boolean
   theme: string
   toggleKeybind: string[]
+  inputDevice?: string
+  autoSave?: boolean
+  shortcuts?: Record<string, string>
+  confidence?: number
+  punctuation?: boolean
 }
 
 let store: any = null
@@ -14,7 +19,12 @@ export async function initializeStore() {
     defaults: {
       startWithWindows: false,
       theme: 'light',
-      toggleKeybind: []
+      toggleKeybind: [],
+      inputDevice: undefined,
+      autoSave: false,
+      shortcuts: {},
+      confidence: 80,
+      punctuation: true
     }
   })
 }
@@ -23,7 +33,12 @@ export function getSettings(): Settings {
   return {
     startWithWindows: store.get('startWithWindows'),
     theme: store.get('theme'),
-    toggleKeybind: store.get('toggleKeybind')
+    toggleKeybind: store.get('toggleKeybind'),
+    inputDevice: store.get('inputDevice'),
+    autoSave: store.get('autoSave'),
+    shortcuts: store.get('shortcuts'),
+    confidence: store.get('confidence'),
+    punctuation: store.get('punctuation')
   }
 }
 
@@ -35,7 +50,7 @@ export function saveSettings(settings: Partial<Settings>) {
       store.set(key, value)
     }
   })
-  
+
   // Handle specific settings
   if ('startWithWindows' in settings) {
     app.setLoginItemSettings({
@@ -47,13 +62,22 @@ export function saveSettings(settings: Partial<Settings>) {
 // Add proper store change event handling
 export function onSettingsChange(callback: (key: string, value: any) => void) {
   if (!store) return
-  
+
   // Listen for changes on each setting key
-  const keys: (keyof Settings)[] = ['startWithWindows', 'theme', 'toggleKeybind']
-  keys.forEach(key => {
+  const keys: (keyof Settings)[] = [
+    'startWithWindows',
+    'theme',
+    'toggleKeybind',
+    'inputDevice',
+    'autoSave',
+    'shortcuts',
+    'confidence',
+    'punctuation'
+  ]
+  keys.forEach((key) => {
     // Use the correct method signature for onDidChange
     store.onDidChange(key.toString(), (newValue: any) => {
       callback(key.toString(), newValue)
     })
   })
-}   
+}

--- a/src/renderer/src/hooks/useSettings.tsx
+++ b/src/renderer/src/hooks/useSettings.tsx
@@ -1,0 +1,67 @@
+import React, { createContext, useContext, useEffect, useState } from 'react'
+
+export interface SettingsState {
+  inputDevice?: string
+  autoSave?: boolean
+  shortcuts?: Record<string, string>
+  confidence?: number
+  punctuation?: boolean
+}
+
+interface SettingsContextValue {
+  settings: SettingsState
+  setSetting: (key: keyof SettingsState, value: any) => void
+  saveSettings: () => void
+}
+
+const SettingsContext = createContext<SettingsContextValue | undefined>(undefined)
+
+export const SettingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [settings, setSettings] = useState<SettingsState>(() => {
+    try {
+      return JSON.parse(localStorage.getItem('settings') || '{}')
+    } catch {
+      return {}
+    }
+  })
+
+  useEffect(() => {
+    const handler = (_: unknown, { key, value }: { key: string; value: any }) => {
+      setSettings((prev) => ({ ...prev, [key]: value }))
+    }
+    if (window.electron?.ipcRenderer) {
+      window.electron.ipcRenderer.invoke('get-settings').then((stored) => {
+        // Merge in values from the main process without clobbering any
+        // changes the user may have already made locally.
+        setSettings((prev) => ({ ...stored, ...prev }))
+      })
+      window.electron.ipcRenderer.on('settings-changed', handler)
+    }
+    return () => {
+      window.electron?.ipcRenderer.removeListener('settings-changed', handler)
+    }
+  }, [])
+
+  const setSetting = (key: keyof SettingsState, value: any) => {
+    setSettings((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const saveSettings = () => {
+    localStorage.setItem('settings', JSON.stringify(settings))
+    window.electron?.ipcRenderer.send('save-settings', settings)
+  }
+
+  return (
+    <SettingsContext.Provider value={{ settings, setSetting, saveSettings }}>
+      {children}
+    </SettingsContext.Provider>
+  )
+}
+
+export function useSettings() {
+  const ctx = useContext(SettingsContext)
+  if (!ctx) {
+    throw new Error('useSettings must be used within SettingsProvider')
+  }
+  return ctx
+}

--- a/src/renderer/src/main-window/Settings.tsx
+++ b/src/renderer/src/main-window/Settings.tsx
@@ -14,9 +14,11 @@ import TranscriptionSettings from "@renderer/main-window/Settings/Transcription"
 import OutputSettings from "@renderer/main-window/Settings/Output";
 import ShortcutsSettings from "@renderer/main-window/Settings/Shortcuts";
 import PrivacySettings from "@renderer/main-window/Settings/Privacy";
+import { useSettings } from "../hooks/useSettings";
 
 export default function TranscriptionSettingsFluent() {
   // --- state --------------------------------------------------------------
+  const { saveSettings } = useSettings();
   const [selectedTab, setSelectedTab] = React.useState<
     "audio" | "transcription" | "output" | "shortcuts" | "privacy"
   >("audio");
@@ -165,7 +167,7 @@ export default function TranscriptionSettingsFluent() {
         {/* Right: Buttons */}
         <div style={{ display: "flex", gap: 12 }}>
           <Button appearance="secondary">Reset to Defaults</Button>
-          <Button appearance="primary">Save Settings</Button>
+          <Button appearance="primary" onClick={saveSettings}>Save Settings</Button>
         </div>
       </div>
     </div>

--- a/src/renderer/src/main-window/Settings/Audio.tsx
+++ b/src/renderer/src/main-window/Settings/Audio.tsx
@@ -1,106 +1,100 @@
-import React from "react";
-import {
-  Label,
-  Dropdown,
-  Option,
-  Slider,
-  Switch,
-} from "@fluentui/react-components";
-import { Mic24Regular } from "@fluentui/react-icons";
-import SectionCard from "./Sectioncard";
-import Row from "./Row";
+import React from 'react'
+import { Label, Dropdown, Option, Slider, Switch } from '@fluentui/react-components'
+import { Mic24Regular } from '@fluentui/react-icons'
+import SectionCard from './Sectioncard'
+import Row from './Row'
+import { useSettings } from '../../hooks/useSettings'
 
 const AudioSettings: React.FC = () => {
-  const [devices, setDevices] = React.useState<MediaDeviceInfo[]>([]);
-  const [selectedDevice, setSelectedDevice] = React.useState<string | undefined>();
+  const { settings, setSetting } = useSettings()
+  const [devices, setDevices] = React.useState<MediaDeviceInfo[]>([])
 
   React.useEffect(() => {
     async function loadDevices() {
       try {
         // Request permission so device labels are populated
-        await navigator.mediaDevices.getUserMedia({ audio: true });
+        await navigator.mediaDevices.getUserMedia({ audio: true })
       } catch {
         // Permission denied or not required
       }
 
       try {
-        const devs = await navigator.mediaDevices.enumerateDevices();
-        setDevices(devs.filter((d) => d.kind === "audioinput"));
+        const devs = await navigator.mediaDevices.enumerateDevices()
+        setDevices(devs.filter((d) => d.kind === 'audioinput'))
       } catch {
-        setDevices([]);
+        setDevices([])
       }
     }
 
-    loadDevices();
-    navigator.mediaDevices.addEventListener("devicechange", loadDevices);
-    return () => navigator.mediaDevices.removeEventListener("devicechange", loadDevices);
-  }, []);
+    loadDevices()
+    navigator.mediaDevices.addEventListener('devicechange', loadDevices)
+    return () => navigator.mediaDevices.removeEventListener('devicechange', loadDevices)
+  }, [])
 
   const handleSelect = (_: any, data: any) => {
-    setSelectedDevice(data.optionValue as string);
-  };
+    const value = data.optionValue as string
+    setSetting('inputDevice', value)
+  }
 
   return (
     <SectionCard
-    icon={<Mic24Regular />}
-    title="Audio Input"
-    description="Configure your microphone and audio input settings"
-  >
-    <div style={{ padding: 24, display: "flex", flexDirection: "column", gap: 24 }}>
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        <Label htmlFor="input-device">Input Device</Label>
-        <Dropdown
-          placeholder="Select microphone"
-          style={{ width: 280 }}
-          value={selectedDevice}
-          onOptionSelect={handleSelect}
-        >
-          {devices.map((device, idx) => (
-            <Option key={device.deviceId} value={device.deviceId}>
-              {device.label || `Microphone ${idx + 1}`}
-            </Option>
-          ))}
-        </Dropdown>
+      icon={<Mic24Regular />}
+      title="Audio Input"
+      description="Configure your microphone and audio input settings"
+    >
+      <div style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 24 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <Label htmlFor="input-device">Input Device</Label>
+          <Dropdown
+            placeholder="Select microphone"
+            style={{ width: 280 }}
+            value={settings.inputDevice}
+            onOptionSelect={handleSelect}
+          >
+            {devices.map((device, idx) => (
+              <Option key={device.deviceId} value={device.deviceId}>
+                {device.label || `Microphone ${idx + 1}`}
+              </Option>
+            ))}
+          </Dropdown>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <Label>Input Gain</Label>
+          <Slider defaultValue={50} max={100} />
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              fontSize: 12,
+              opacity: 0.6
+            }}
+          >
+            <span>Low</span>
+            <span>High</span>
+          </div>
+        </div>
+
+        <Row>
+          <div>
+            <Label>Noise Reduction</Label>
+            <p style={{ fontSize: 12, opacity: 0.6 }}>
+              Reduce background noise during transcription
+            </p>
+          </div>
+          <Switch defaultChecked aria-label="Noise reduction" />
+        </Row>
+
+        <Row>
+          <div>
+            <Label>Auto Gain Control</Label>
+            <p style={{ fontSize: 12, opacity: 0.6 }}>Automatically adjust input levels</p>
+          </div>
+          <Switch defaultChecked aria-label="Auto gain" />
+        </Row>
       </div>
+    </SectionCard>
+  )
+}
 
-      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-        <Label>Input Gain</Label>
-        <Slider defaultValue={50} max={100} />
-        <div
-          style={{
-            display: "flex",
-            justifyContent: "space-between",
-            fontSize: 12,
-            opacity: 0.6,
-          }}
-        >
-          <span>Low</span>
-          <span>High</span>
-        </div>
-      </div>
-
-      <Row>
-        <div>
-          <Label>Noise Reduction</Label>
-          <p style={{ fontSize: 12, opacity: 0.6 }}>
-            Reduce background noise during transcription
-          </p>
-        </div>
-        <Switch defaultChecked aria-label="Noise reduction" />
-      </Row>
-
-      <Row>
-        <div>
-          <Label>Auto Gain Control</Label>
-          <p style={{ fontSize: 12, opacity: 0.6 }}>
-            Automatically adjust input levels
-          </p>
-        </div>
-        <Switch defaultChecked aria-label="Auto gain" />
-      </Row>
-    </div>
-  </SectionCard>
-  );
-};
-
-export default AudioSettings;
+export default AudioSettings

--- a/src/renderer/src/main-window/Settings/Output.tsx
+++ b/src/renderer/src/main-window/Settings/Output.tsx
@@ -1,105 +1,112 @@
-
-
-import React from "react";
-import { Label, Dropdown, Option, Input, Switch, Button, Text, Divider } from "@fluentui/react-components";
-import { Folder24Regular } from "@fluentui/react-icons";
-import SectionCard from "./Sectioncard";
-import Row from "./Row";
-
+import React from 'react'
+import {
+  Label,
+  Dropdown,
+  Option,
+  Input,
+  Switch,
+  Button,
+  Text,
+  Divider
+} from '@fluentui/react-components'
+import { Folder24Regular } from '@fluentui/react-icons'
+import SectionCard from './Sectioncard'
+import Row from './Row'
+import { useSettings } from '../../hooks/useSettings'
 
 const OutputSettings: React.FC = () => {
-    // Add the use of React state for confidence and punctuation
-    const [autoSave, setAutoSave] = React.useState<boolean>(false);
+  const { settings, setSetting } = useSettings()
 
-    return (<SectionCard
-        icon={<Folder24Regular />}
-        title="Output Settings"
-        description="Configure how transcriptions are saved and exported"
+  return (
+    <SectionCard
+      icon={<Folder24Regular />}
+      title="Output Settings"
+      description="Configure how transcriptions are saved and exported"
     >
-        <div style={{ padding: 24, display: "flex", flexDirection: "column", gap: 24 }}>
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                <Label>Default Save Location</Label>
-                <div style={{ display: "flex", gap: 8 }}>
-                    <Input value="/Users/username/Documents/Transcriptions" readOnly style={{ flex: 1 }} />
-                    <Button appearance="secondary">Browse</Button>
-                </div>
-            </div>
-
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                <Label>Default File Format</Label>
-                <Dropdown placeholder="Select format" style={{ width: 220 }}>
-                    {[
-                        ["txt", "Plain Text (.txt)"],
-                        ["docx", "Word Document (.docx)"],
-                        ["pdf", "PDF Document (.pdf)"],
-                        ["srt", "Subtitle File (.srt)"],
-                        ["vtt", "WebVTT (.vtt)"],
-                        ["json", "JSON (.json)"],
-                    ].map(([val, label]) => (
-                        <Option key={val} value={val}>
-                            {label}
-                        </Option>
-                    ))}
-                </Dropdown>
-            </div>
-
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                <Label>File Naming Convention</Label>
-                <Dropdown placeholder="Select naming pattern" style={{ width: 260 }}>
-                    <Option value="timestamp">Timestamp (2024-01-15_14-30-25)</Option>
-                    <Option value="date">Date Only (2024-01-15)</Option>
-                    <Option value="custom">Custom Prefix + Timestamp</Option>
-                    <Option value="manual">Manual Naming</Option>
-                </Dropdown>
-            </div>
-
-            <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                <Label>Custom Prefix</Label>
-                <Input placeholder="e.g., Meeting, Interview, Notes" />
-            </div>
-
-            <Divider />
-
-            <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-                <h4 style={{ fontWeight: 500 }}>Auto‑Save Options</h4>
-
-                <Row>
-                    <div>
-                        <Label>Auto‑save Transcriptions</Label>
-                        <p style={{ fontSize: 12, opacity: 0.6 }}>
-                            Automatically save completed transcriptions
-                        </p>
-                    </div>
-                    <Switch
-                        checked={autoSave}
-                        onChange={(_, data) => setAutoSave(data.checked)}
-                        aria-label="Auto save"
-                    />
-                </Row>
-
-                <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-                    <Label>Auto‑save Interval</Label>
-                    <Dropdown placeholder="Select interval" style={{ width: 180 }}>
-                        <Option value="30">Every 30 seconds</Option>
-                        <Option value="60">Every minute</Option>
-                        <Option value="300">Every 5 minutes</Option>
-                        <Option value="600">Every 10 minutes</Option>
-                    </Dropdown>
-                </div>
-
-                <Row>
-                    <div>
-                        <Label>Create Backup Copies</Label>
-                        <p style={{ fontSize: 12, opacity: 0.6 }}>
-                            Keep backup copies of transcriptions
-                        </p>
-                    </div>
-                    <Switch aria-label="Backups" />
-                </Row>
-            </div>
+      <div style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 24 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <Label>Default Save Location</Label>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <Input value="/Users/username/Documents/Transcriptions" readOnly style={{ flex: 1 }} />
+            <Button appearance="secondary">Browse</Button>
+          </div>
         </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <Label>Default File Format</Label>
+          <Dropdown placeholder="Select format" style={{ width: 220 }}>
+            {[
+              ['txt', 'Plain Text (.txt)'],
+              ['docx', 'Word Document (.docx)'],
+              ['pdf', 'PDF Document (.pdf)'],
+              ['srt', 'Subtitle File (.srt)'],
+              ['vtt', 'WebVTT (.vtt)'],
+              ['json', 'JSON (.json)']
+            ].map(([val, label]) => (
+              <Option key={val} value={val}>
+                {label}
+              </Option>
+            ))}
+          </Dropdown>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <Label>File Naming Convention</Label>
+          <Dropdown placeholder="Select naming pattern" style={{ width: 260 }}>
+            <Option value="timestamp">Timestamp (2024-01-15_14-30-25)</Option>
+            <Option value="date">Date Only (2024-01-15)</Option>
+            <Option value="custom">Custom Prefix + Timestamp</Option>
+            <Option value="manual">Manual Naming</Option>
+          </Dropdown>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <Label>Custom Prefix</Label>
+          <Input placeholder="e.g., Meeting, Interview, Notes" />
+        </div>
+
+        <Divider />
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+          <h4 style={{ fontWeight: 500 }}>Auto‑Save Options</h4>
+
+          <Row>
+            <div>
+              <Label>Auto‑save Transcriptions</Label>
+              <p style={{ fontSize: 12, opacity: 0.6 }}>
+                Automatically save completed transcriptions
+              </p>
+            </div>
+            <Switch
+              checked={settings.autoSave ?? false}
+              onChange={(_, data) => {
+                setSetting('autoSave', data.checked)
+              }}
+              aria-label="Auto save"
+            />
+          </Row>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <Label>Auto‑save Interval</Label>
+            <Dropdown placeholder="Select interval" style={{ width: 180 }}>
+              <Option value="30">Every 30 seconds</Option>
+              <Option value="60">Every minute</Option>
+              <Option value="300">Every 5 minutes</Option>
+              <Option value="600">Every 10 minutes</Option>
+            </Dropdown>
+          </div>
+
+          <Row>
+            <div>
+              <Label>Create Backup Copies</Label>
+              <p style={{ fontSize: 12, opacity: 0.6 }}>Keep backup copies of transcriptions</p>
+            </div>
+            <Switch aria-label="Backups" />
+          </Row>
+        </div>
+      </div>
     </SectionCard>
-    )
+  )
 }
 
-export default OutputSettings;
+export default OutputSettings

--- a/src/renderer/src/main-window/Settings/Shortcuts.tsx
+++ b/src/renderer/src/main-window/Settings/Shortcuts.tsx
@@ -1,154 +1,163 @@
-import React from "react";
-import { Label, Switch, Badge, Text, Divider, Dialog, DialogSurface, DialogBody, DialogTitle, DialogContent, DialogActions, Button } from "@fluentui/react-components";
-import { Keyboard24Regular } from "@fluentui/react-icons";
-import SectionCard from "./Sectioncard";
-import Row from "./Row";
+import React from 'react'
+import {
+  Label,
+  Switch,
+  Badge,
+  Text,
+  Divider,
+  Dialog,
+  DialogSurface,
+  DialogBody,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button
+} from '@fluentui/react-components'
+import { Keyboard24Regular } from '@fluentui/react-icons'
+import SectionCard from './Sectioncard'
+import Row from './Row'
+import { useSettings } from '../../hooks/useSettings'
 
 const ShortcutsSettings: React.FC = () => {
+  const { settings, setSetting } = useSettings()
 
-    const [editingShortcut, setEditingShortcut] = React.useState<string | null>(null);
-    const [shortcuts, setShortcuts] = React.useState<Record<string, string>>({
-        startStop: "Ctrl+Shift+R",
-        pauseResume: "Ctrl+Shift+P",
-        save: "Ctrl+Shift+S",
-        new: "Ctrl+Shift+N",
-        settings: "Ctrl+Shift+O",
-        mute: "Ctrl+Shift+M",
-    });
+  const [editingShortcut, setEditingShortcut] = React.useState<string | null>(null)
+  const shortcuts = settings.shortcuts || {
+    startStop: 'Ctrl+Shift+R',
+    pauseResume: 'Ctrl+Shift+P',
+    save: 'Ctrl+Shift+S',
+    new: 'Ctrl+Shift+N',
+    settings: 'Ctrl+Shift+O',
+    mute: 'Ctrl+Shift+M'
+  }
 
-    const [capturedKeys, setCapturedKeys] = React.useState<string[]>([]);
+  const [capturedKeys, setCapturedKeys] = React.useState<string[]>([])
 
-    const handleKeyCapture = (event: KeyboardEvent) => {
-        const key = event.key.toLowerCase();
-        setCapturedKeys(prev => prev.includes(key) ? prev : [...prev, key]);
-    };
-    React.useEffect(() => {
-        if (editingShortcut === null) return;
-        window.addEventListener("keydown", handleKeyCapture);
-        return () => window.removeEventListener("keydown", handleKeyCapture);
-    }, [editingShortcut]);
+  const handleKeyCapture = (event: KeyboardEvent) => {
+    const key = event.key.toLowerCase()
+    setCapturedKeys((prev) => (prev.includes(key) ? prev : [...prev, key]))
+  }
+  React.useEffect(() => {
+    if (editingShortcut === null) return
+    window.addEventListener('keydown', handleKeyCapture)
+    return () => window.removeEventListener('keydown', handleKeyCapture)
+  }, [editingShortcut])
 
-    const cancelShortcut = () => {
-        setEditingShortcut(null);
-        setCapturedKeys([]);
-    };
+  const cancelShortcut = () => {
+    setEditingShortcut(null)
+    setCapturedKeys([])
+  }
 
-    const saveShortcut = () => {
-        if (capturedKeys.length > 0) {
-            setShortcuts({ ...shortcuts, [editingShortcut as string]: capturedKeys.join(" + ") });
-            setEditingShortcut(null);
-            setCapturedKeys([]);
-        }
-    };
+  const saveShortcut = () => {
+    if (capturedKeys.length > 0 && editingShortcut) {
+      const updated = { ...shortcuts, [editingShortcut]: capturedKeys.join(' + ') }
+      setSetting('shortcuts', updated)
+      setEditingShortcut(null)
+      setCapturedKeys([])
+    }
+  }
 
-    return (
-        <SectionCard
-            icon={<Keyboard24Regular />}
-            title="Keyboard Shortcuts"
-            description="Customize keyboard shortcuts for quick access"
-        >
-            <div style={{ padding: 24, display: "flex", flexDirection: "column", gap: 24 }}>
-                {[
-                    ["startStop", "Start/Stop Recording", "Toggle transcription recording"],
-                    ["pauseResume", "Pause/Resume", "Pause or resume transcription"],
-                    ["save", "Save Transcription", "Save current transcription"],
-                    ["new", "New Transcription", "Start a new transcription session"],
-                    ["settings", "Open Settings", "Open settings window"],
-                    ["mute", "Toggle Mute", "Mute/unmute microphone"],
-                ].map(([key, label, desc]) => (
-                    <Row key={key as string}>
-                        <div>
-                            <Label>{label}</Label>
-                            <p style={{ fontSize: 12, opacity: 0.6 }}>{desc}</p>
-                        </div>
-                        <Badge
-                            appearance="outline"
-                            style={{ cursor: "pointer" }}
-                            onClick={() => setEditingShortcut(key as string)}
-                        >
-                            {shortcuts[key as string]}
-                        </Badge>
-                    </Row>
-                ))}
-
-                <Divider />
-
-                <Row>
-                    <div>
-                        <Label>Global Shortcuts</Label>
-                        <p style={{ fontSize: 12, opacity: 0.6 }}>
-                            Enable shortcuts when app is not focused
-                        </p>
-                    </div>
-                    <Switch aria-label="Global shortcuts" />
-                </Row>
+  return (
+    <SectionCard
+      icon={<Keyboard24Regular />}
+      title="Keyboard Shortcuts"
+      description="Customize keyboard shortcuts for quick access"
+    >
+      <div style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 24 }}>
+        {[
+          ['startStop', 'Start/Stop Recording', 'Toggle transcription recording'],
+          ['pauseResume', 'Pause/Resume', 'Pause or resume transcription'],
+          ['save', 'Save Transcription', 'Save current transcription'],
+          ['new', 'New Transcription', 'Start a new transcription session'],
+          ['settings', 'Open Settings', 'Open settings window'],
+          ['mute', 'Toggle Mute', 'Mute/unmute microphone']
+        ].map(([key, label, desc]) => (
+          <Row key={key as string}>
+            <div>
+              <Label>{label}</Label>
+              <p style={{ fontSize: 12, opacity: 0.6 }}>{desc}</p>
             </div>
-
-            {/* Shortcut dialog */}
-            <Dialog
-                open={editingShortcut !== null}
-                modalType="alert"
-                onOpenChange={(_, data) => !data.open && cancelShortcut()}
+            <Badge
+              appearance="outline"
+              style={{ cursor: 'pointer' }}
+              onClick={() => setEditingShortcut(key as string)}
             >
-                <DialogSurface>
-                    <DialogBody>
-                        <DialogTitle>Change Keyboard Shortcut</DialogTitle>
-                        <DialogContent>
-                            <div
-                                style={{
-                                    textAlign: "center",
-                                    padding: 32,
-                                    border: "2px dashed var(--colorNeutralStroke2)",
-                                    borderRadius: 8,
-                                    marginBottom: 24,
-                                }}
-                            >
-                                <Keyboard24Regular
-                                    style={{
-                                        width: 32,
-                                        height: 32,
-                                        opacity: 0.6,
-                                        marginBottom: 8,
-                                    }}
-                                />
-                                <p
-                                    style={{
-                                        fontSize: 12,
-                                        opacity: 0.6,
-                                        marginBottom: 16,
-                                    }}
-                                >
-                                    Press your desired key combination
-                                </p>
-                                <Text
-                                    weight="semibold"
-                                    style={{
-                                        fontFamily: "monospace",
-                                        fontSize: 16,
-                                    }}
-                                >
-                                    {capturedKeys.length > 0
-                                        ? capturedKeys.join(" + ")
-                                        : "Waiting for input..."}
-                                </Text>
-                            </div>
-                        </DialogContent>
-                        <DialogActions>
-                            <Button appearance="secondary" onClick={cancelShortcut}>
-                                Cancel
-                            </Button>
-                            <Button
-                                onClick={saveShortcut}
-                                disabled={capturedKeys.length < 2}
-                            >
-                                Save Shortcut
-                            </Button>
-                        </DialogActions>
-                    </DialogBody>
-                </DialogSurface>
-            </Dialog>
-        </SectionCard>
-    )
+              {shortcuts[key as string]}
+            </Badge>
+          </Row>
+        ))}
+
+        <Divider />
+
+        <Row>
+          <div>
+            <Label>Global Shortcuts</Label>
+            <p style={{ fontSize: 12, opacity: 0.6 }}>Enable shortcuts when app is not focused</p>
+          </div>
+          <Switch aria-label="Global shortcuts" />
+        </Row>
+      </div>
+
+      {/* Shortcut dialog */}
+      <Dialog
+        open={editingShortcut !== null}
+        modalType="alert"
+        onOpenChange={(_, data) => !data.open && cancelShortcut()}
+      >
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Change Keyboard Shortcut</DialogTitle>
+            <DialogContent>
+              <div
+                style={{
+                  textAlign: 'center',
+                  padding: 32,
+                  border: '2px dashed var(--colorNeutralStroke2)',
+                  borderRadius: 8,
+                  marginBottom: 24
+                }}
+              >
+                <Keyboard24Regular
+                  style={{
+                    width: 32,
+                    height: 32,
+                    opacity: 0.6,
+                    marginBottom: 8
+                  }}
+                />
+                <p
+                  style={{
+                    fontSize: 12,
+                    opacity: 0.6,
+                    marginBottom: 16
+                  }}
+                >
+                  Press your desired key combination
+                </p>
+                <Text
+                  weight="semibold"
+                  style={{
+                    fontFamily: 'monospace',
+                    fontSize: 16
+                  }}
+                >
+                  {capturedKeys.length > 0 ? capturedKeys.join(' + ') : 'Waiting for input...'}
+                </Text>
+              </div>
+            </DialogContent>
+            <DialogActions>
+              <Button appearance="secondary" onClick={cancelShortcut}>
+                Cancel
+              </Button>
+              <Button onClick={saveShortcut} disabled={capturedKeys.length < 2}>
+                Save Shortcut
+              </Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+    </SectionCard>
+  )
 }
 
-export default ShortcutsSettings;
+export default ShortcutsSettings

--- a/src/renderer/src/main-window/Settings/Transcription.tsx
+++ b/src/renderer/src/main-window/Settings/Transcription.tsx
@@ -1,14 +1,21 @@
-
-import React from "react";
-import { Label, Dropdown, Option, Slider, Switch, Badge, Text, Divider } from "@fluentui/react-components";
-import { TextGrammarWand24Regular } from "@fluentui/react-icons";
-import SectionCard from "./Sectioncard";
-import Row from "./Row";
+import React from 'react'
+import {
+  Label,
+  Dropdown,
+  Option,
+  Slider,
+  Switch,
+  Badge,
+  Text,
+  Divider
+} from '@fluentui/react-components'
+import { TextGrammarWand24Regular } from '@fluentui/react-icons'
+import SectionCard from './Sectioncard'
+import Row from './Row'
+import { useSettings } from '../../hooks/useSettings'
 
 const TranscriptionSettings: React.FC = () => {
-  // Add the use of React state for confidence and punctuation
-  const [confidence, setConfidence] = React.useState<number>(80);
-  const [punctuation, setPunctuation] = React.useState<boolean>(true);
+  const { settings, setSetting } = useSettings()
 
   return (
     <SectionCard
@@ -16,21 +23,21 @@ const TranscriptionSettings: React.FC = () => {
       title="Language & Model"
       description="Configure transcription language and model settings"
     >
-      <div style={{ padding: 24, display: "flex", flexDirection: "column", gap: 24 }}>
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <div style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 24 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <Label>Primary Language</Label>
           <Dropdown placeholder="Select language" style={{ width: 220 }}>
             {[
-              ["en", "English"],
-              ["es", "Spanish"],
-              ["fr", "French"],
-              ["de", "German"],
-              ["it", "Italian"],
-              ["pt", "Portuguese"],
-              ["ru", "Russian"],
-              ["ja", "Japanese"],
-              ["ko", "Korean"],
-              ["zh", "Chinese"],
+              ['en', 'English'],
+              ['es', 'Spanish'],
+              ['fr', 'French'],
+              ['de', 'German'],
+              ['it', 'Italian'],
+              ['pt', 'Portuguese'],
+              ['ru', 'Russian'],
+              ['ja', 'Japanese'],
+              ['ko', 'Korean'],
+              ['zh', 'Chinese']
             ].map(([val, label]) => (
               <Option key={val} value={val}>
                 {label}
@@ -39,7 +46,7 @@ const TranscriptionSettings: React.FC = () => {
           </Dropdown>
         </div>
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <Label>Transcription Model</Label>
           <Dropdown placeholder="Select model" style={{ width: 220 }}>
             <Option value="whisper-base" text="Whisper Base">
@@ -60,24 +67,27 @@ const TranscriptionSettings: React.FC = () => {
           </Text>
         </div>
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
           <Label>Confidence Threshold</Label>
           <Slider
-            value={confidence}
-            onChange={(_, data) => setConfidence(data.value as number)}
+            value={settings.confidence ?? 80}
+            onChange={(_, data) => {
+              const val = data.value as number
+              setSetting('confidence', val)
+            }}
             max={100}
             step={5}
           />
           <div
             style={{
-              display: "flex",
-              justifyContent: "space-between",
+              display: 'flex',
+              justifyContent: 'space-between',
               fontSize: 12,
-              opacity: 0.6,
+              opacity: 0.6
             }}
           >
             <span>0%</span>
-            <span>{confidence}%</span>
+            <span>{settings.confidence ?? 80}%</span>
             <span>100%</span>
           </div>
           <Text size={200} style={{ opacity: 0.6 }}>
@@ -87,25 +97,25 @@ const TranscriptionSettings: React.FC = () => {
 
         <Divider />
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
           <h4 style={{ fontWeight: 500 }}>Processing Options</h4>
           <Row>
             <div>
               <Label>Auto Punctuation</Label>
-              <p style={{ fontSize: 12, opacity: 0.6 }}>
-                Automatically add punctuation marks
-              </p>
+              <p style={{ fontSize: 12, opacity: 0.6 }}>Automatically add punctuation marks</p>
             </div>
             <Switch
-              checked={punctuation}
-              onChange={(_, data) => setPunctuation(data.checked)}
+              checked={settings.punctuation ?? true}
+              onChange={(_, data) => {
+                setSetting('punctuation', data.checked)
+              }}
               aria-label="Auto punctuation"
             />
           </Row>
         </div>
       </div>
     </SectionCard>
-  );
-};
+  )
+}
 
-export default TranscriptionSettings;
+export default TranscriptionSettings

--- a/src/renderer/src/main-window/main.tsx
+++ b/src/renderer/src/main-window/main.tsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client'
 import App from './App'
 import { FluentProvider, webDarkTheme } from '@fluentui/react-components'
 import TranscriptionSettingsFluent from '@renderer/main-window/Settings'
+import { SettingsProvider } from '../hooks/useSettings'
 
 const rootElement = document.getElementById('root')
 if (!rootElement) {
@@ -17,8 +18,9 @@ const root = createRoot(rootElement)
 root.render(
   <StrictMode>
     <FluentProvider theme={webDarkTheme} style={{ height: '100%', width: '100%' }}>
-      <TranscriptionSettingsFluent />
+      <SettingsProvider>
+        <TranscriptionSettingsFluent />
+      </SettingsProvider>
     </FluentProvider>
-
   </StrictMode>
 )

--- a/src/renderer/src/overlay-window/App.tsx
+++ b/src/renderer/src/overlay-window/App.tsx
@@ -1,14 +1,32 @@
-import * as React from 'react';
-import { Button, Text, Title3 } from '@fluentui/react-components';
+import * as React from 'react'
+import { Button, Text, Title3 } from '@fluentui/react-components'
+import { useSettings } from '../hooks/useSettings'
 
 function App(): React.JSX.Element {
-  const ipcHandle = (): void => window.electron.ipcRenderer.send('ping');
+  const { settings } = useSettings()
+  const ipcHandle = (): void => window.electron.ipcRenderer.send('ping')
 
   return (
-    <div style={{ minWidth: 360, padding: 32, display: 'flex', flexDirection: 'column', gap: 20, alignItems: 'center', background: 'transparent', boxShadow: 'none' }}>
+    <div
+      style={{
+        minWidth: 360,
+        padding: 32,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 20,
+        alignItems: 'center',
+        background: 'transparent',
+        boxShadow: 'none'
+      }}
+    >
       <Title3>OVERLAY</Title3>
-      <Text>Build an Electron app with <b>React</b> and <b>TypeScript</b> using Fluent UI.</Text>
-      <Text>Try pressing <code>F12</code> to open the DevTools.</Text>
+      <Text>
+        Build an Electron app with <b>React</b> and <b>TypeScript</b> using Fluent UI.
+      </Text>
+      <Text>
+        Try pressing <code>F12</code> to open the DevTools.
+      </Text>
+      <Text>Current input device: {settings.inputDevice || 'system default'}</Text>
       <div style={{ display: 'flex', gap: 12 }}>
         <Button as="a" href="https://react.fluentui.dev/" target="_blank" appearance="primary">
           Fluent UI Docs
@@ -18,7 +36,7 @@ function App(): React.JSX.Element {
         </Button>
       </div>
     </div>
-  );
+  )
 }
 
-export default App;
+export default App

--- a/src/renderer/src/overlay-window/main.tsx
+++ b/src/renderer/src/overlay-window/main.tsx
@@ -1,23 +1,26 @@
-import '../assets/overlay.css';
+import '../assets/overlay.css'
 
-import { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
-import App from './App';
-import { FluentProvider, webDarkTheme } from '@fluentui/react-components';
-import Pill from '../components/Pill';
-const rootElement = document.getElementById('root');
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import { FluentProvider, webDarkTheme } from '@fluentui/react-components'
+import Pill from '../components/Pill'
+import { SettingsProvider } from '../hooks/useSettings'
+const rootElement = document.getElementById('root')
 if (!rootElement) {
-  throw new Error('Failed to find the root element');
+  throw new Error('Failed to find the root element')
 }
 
-console.log('Mounting React application...');
-const root = createRoot(rootElement);
+console.log('Mounting React application...')
+const root = createRoot(rootElement)
 
 root.render(
   <StrictMode>
     <FluentProvider theme={webDarkTheme}>
-      {/* <App /> */}
-      <Pill />
+      <SettingsProvider>
+        {/* <App /> */}
+        <Pill />
+      </SettingsProvider>
     </FluentProvider>
   </StrictMode>
-);
+)


### PR DESCRIPTION
## Summary
- add `useSettings` hook with `SettingsProvider`
- wrap main window with provider
- update settings screens to write to context
- save settings to electron store and `localStorage`
- merge main process settings without clobbering unsaved state
- rely on provider values for settings UI

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840bbc3a4088327b034e64dd38a49bb